### PR TITLE
chore: add vite library and npm publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "GraphWaGu",
   "version": "0.1.0",
+  "main": "./dist/graphwagu.mjs",
   "private": true,
   "dependencies": {
     "@types/file-saver": "^2.0.7",
@@ -17,10 +18,13 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build --mode html",
+    "build-html": "tsc && vite build --mode html",
+    "build-lib": "tsc && vite build --mode lib",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "deploy": "pnpm run build && sh deploy.sh"
+    "deploy": "pnpm run build-html && sh deploy.sh",
+    "prepublishOnly": "pnpm run build-lib"
   },
   "devDependencies": {
     "@vitejs/plugin-react-swc": "^3.3.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,41 @@
-import { defineConfig } from 'vite';
+import { defineConfig, sortUserPlugins } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
-export default defineConfig({
-    plugins: [react()],
-    base: '/GraphWaGu/',
-    build: {
-        rollupOptions: {
-            external: [/\.json$/],
-        },
-    },
+export default defineConfig(({ mode }) => {
+    let plugins = [react()];
+    let base = '/GraphWaGu/';
+
+    if (mode == 'html' || mode === undefined) {
+        return {
+            plugins: plugins,
+            base: base,
+            build: {
+                rollupOptions: {
+                    external: [/\.json$/],
+                },
+            },
+        }
+    }
+
+    if (mode == 'lib') {
+        return {
+            plugins: plugins,
+            base: base,
+            publicDir: false,
+            build: {
+                lib: {
+                    name: 'GraphWaGu',
+                    entry: ['src/webgpu/force_directed.ts'],
+                    formats: ['es'],
+                    fileName: 'graphwagu',
+                },
+                rollupOptions: {
+                    external: ['public'],
+                },
+                sourcemap: true,
+            },
+        }
+    }
+
+    throw new Error(`unknown vite mode: ${mode}`)
 });


### PR DESCRIPTION
Changes:
- git ignore `dist` folder
- Create `build-html` npm script (does the same thing as `build`)
- Create `build-lib` npm script
- Refactor vite config to build html and library options
- Export library from `package.json`

Notes:
- You might want to consider [creating an npm organization](https://docs.npmjs.com/creating-an-organization) and converting this to an [organization scoped package](https://docs.npmjs.com/creating-and-publishing-an-organization-scoped-package) (e.g. - `npm install @harp-lab/GraphWaGu`)
- I haven't actually tried to import this package yet to see if it works :)